### PR TITLE
Add back kind config file

### DIFF
--- a/kind-config.yaml
+++ b/kind-config.yaml
@@ -1,0 +1,8 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  extraPortMappings:
+  - containerPort: 30201
+    hostPort: 30201
+    listenAddress: "0.0.0.0"


### PR DESCRIPTION
Our tutorial relies on a kind config for testing against a local k8s cluster